### PR TITLE
expand javascript support

### DIFF
--- a/index.less
+++ b/index.less
@@ -12,6 +12,7 @@
 @import 'languages/gfm';
 @import 'languages/ini';
 @import 'languages/java';
+@import 'languages/javascript';
 @import 'languages/json';
 @import 'languages/ruby';
 @import 'languages/python';

--- a/spec/javascript.js
+++ b/spec/javascript.js
@@ -1,16 +1,116 @@
-function $initHighlight(block, flags) {
-  try {
-    if (block.className.search(/\bno\-highlight\b/) != -1)
-      return processBlock(block.function, true, 0x0F) + ' class=""';
-  } catch (e) {
-    /* handle exception */
-    var e4x =
-        <div>Example
-            <p>1234</p></div>;
-  }
-  for (var i = 0 / 2; i < classes.length; i++) { // "0 / 2" should not be parsed as regexp
-    if (checkCondition(classes[i]) === undefined)
-      return /\d+[\s/]/g;
-  }
-  console.log(Array.every(classes, Boolean));
+// jsdoc
+
+/**
+ * @param {string[]} str
+ * @return {string}
+ */
+
+// import and export
+
+import { assign } from 'lodash';
+
+export const TEST = 5;
+
+export default {};
+
+// variables and values
+
+var abc, def;
+var n = 0 + n++;
+var s = 'string';
+var b = true || false;
+var { n } = { n: null };
+var u = undefined;
+let l = 'scoped'.length;
+let oct = 0x0F;
+const [ LETTERS ] = 'ok' && my.nested['alphabet'].property[0];
+const r = /^([A-Z\.].)a+b*c?$/igmyu;
+const intr = `Hello ${world.toUpperCase()}!`;
+const arr = [];
+
+// functions
+
+calling();
+new Calling();
+calling.call(null);
+calling.apply(null);
+calling.bind(null);
+
+function* Func() {
+    this.fn1 = function() {};
+    this.fn2 = () => {};
+    this.fn3 = arg => {};
+    this.var = 0;
+    yield;
+    return;
 }
+
+Func.prototype.fn4 = () => {};
+
+Func.call();
+
+String();
+Boolean();
+Array.isArray();
+Number.isNaN();
+Number.prototype.parseInt.call();
+
+var obj = {
+    get prop () {},
+    set prop (v) {},
+    shortFn() {},
+    fn: () => {},
+    key1: 0,
+    [key2]: 0,
+};
+
+class Duck extends Animal {
+    constructor() {}
+    quack() { super.quack(); }
+    static count1() {}
+}
+
+var FemaleDuck = class extends Duck {};
+
+var d = new Duck();
+
+// constructs
+
+if (a === true) {}
+else {}
+
+switch (val) {
+    default:
+    case 0:
+        break;
+}
+
+for (let i = 0; i < 10; i++) {
+    continue;
+}
+
+while (a !== 1 && b == true) {}
+
+do {} while (c <= 0 || d >= 1);
+
+try {}
+catch (err) {}
+finally {}
+
+// global
+
+global.setTimeout();
+window.setInterval();
+console.log();
+
+JSON.parse();
+
+// node
+
+var mod = require('mod');
+
+exports.fn = () => {};
+module.exports = { n, x };
+
+process.exit(-1);
+process.env.PORT;

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -24,4 +24,7 @@
   .support.class
     { color: @gruvbox-bright-yellow; }
 
+  .quasi .punctuation
+    { color: @gruvbox-bright-aqua; }
+
 }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,0 +1,27 @@
+.source.js {
+
+  /**
+   * System types and global variables.
+   * - this
+   * - super
+   * - prototype
+   * - process
+   * - module / module.exports
+   * - window / global
+   */
+  .language.variable,
+  .support.type,
+  .support.type .keyword
+    { color: @gruvbox-bright-orange; }
+
+  /**
+   * Make no distiction between classes and functions. (as there is none).
+   * Differ color from string. Don't differ support function from normal function.
+   */
+  .function.name,
+  .class.name,
+  .support.function,
+  .support.class
+    { color: @gruvbox-bright-yellow; }
+
+}


### PR DESCRIPTION
Would you mind including this improvement for JavaScript highlighting.
- No difference between functions and classes, as there is none.
- No difference between functions on support types and regular functions. (thus freeing up orange)
- System types and properties in orange.
- Interpolation punctuation in aqua
