### PR TITLE
Color for support.type

### DIFF
--- a/styles/language.less
+++ b/styles/language.less
@@ -163,6 +163,10 @@
 }
 
 .support {
+  &.type {
+    color: @gruvbox-bright-orange;
+  }
+
   &.class {
     color: @gruvbox-bright-yellow;
   }


### PR DESCRIPTION
Hi!
Recently I started using Gruvbox theme (it's beautiful, thanks for great work! :heart:) and I noticed some types in my C code were not highlighted.

![selection_840](https://cloud.githubusercontent.com/assets/6173262/18037223/1434f0a6-6d7f-11e6-8d6a-e418e0838b54.png)

I decided to examine what's going on, and finally I managed to modify `language.less` file in order to add color entry for `support.type` (`uint8_t`, `int16_t`, `anything_t` as declared by `language-c` package).

![selection_841](https://cloud.githubusercontent.com/assets/6173262/18037254/d930d140-6d7f-11e6-99fe-26294c082c0a.png)
_I think that looks much better, doesn't it?_

I chose orange, because library calls like `malloc` or `printf` are the same color now (like in for example One Dark theme)

It's the first time ever I modified Atom package files, so I hope I didn't break anything.
Anyway, if something's wrong, please let me know, I'm willing to fix it :)
