### PR TITLE
update selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,7 +1,6 @@
 // Editor styles (background, gutter, guides)
 
-atom-text-editor, // <- remove when Shadow DOM can't be disabled
-:host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,295 +1,295 @@
 // Language syntax highlighting
 
-.comment {
+.syntax--comment {
   color: @gruvbox-medium;
   font-style: italic;
 
-  /* Keywords inside comments (e.g. yard, javadoc, etc) should be more subdued
+  /* Keywords inside comments (e.syntax--g.syntax-- yard, javadoc, etc) should be more subdued
      than other keywords */
-  .keyword, .keyword.punctuation { color: @gruvbox-light2; }
-  .punctuation { color: @gruvbox-light3; }
-  .string, .type, .parameter { color: @gruvbox-light3; }
+  .syntax--keyword, .syntax--keyword.syntax--punctuation { color: @gruvbox-light2; }
+  .syntax--punctuation { color: @gruvbox-light3; }
+  .syntax--string, .syntax--type, .syntax--parameter { color: @gruvbox-light3; }
 }
 
-.entity {
-  &.name.type {
+.syntax--entity {
+  &.syntax--name.syntax--type {
     color: @gruvbox-bright-yellow;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @gruvbox-bright-yellow;
   }
 }
 
-.keyword {
+.syntax--keyword {
   color: @gruvbox-bright-red;
 
-  &.control {
+  &.syntax--control {
     color: @gruvbox-bright-red;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @syntax-fg;
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @gruvbox-bright-orange;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @gruvbox-bright-purple;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @gruvbox-bright-red;
 
-  &.type {
-    &.annotation,
-    &.primitive {
+  &.syntax--type {
+    &.syntax--annotation,
+    &.syntax--primitive {
       color: @gruvbox-bright-red;
     }
   }
 
-  &.modifier {
-    &.package,
-    &.import {
+  &.syntax--modifier {
+    &.syntax--package,
+    &.syntax--import {
       color: @syntax-fg;
     }
   }
 }
 
-.constant {
+.syntax--constant {
   color: @gruvbox-bright-purple;
 
-  &.variable {
+  &.syntax--variable {
     color: @gruvbox-bright-purple;
   }
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @gruvbox-bright-red;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @gruvbox-bright-purple;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @gruvbox-bright-red;
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @gruvbox-bright-purple;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @gruvbox-bright-blue;
 
-  &.interpolation {
+  &.syntax--interpolation {
     color: @gruvbox-neutral-blue;
   }
 
-  &.parameter {
+  &.syntax--parameter {
     color: @syntax-fg;
   }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   background-color: @gruvbox-bright-blue;
   color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
   color: @gruvbox-bright-green;
 
-  &.regexp {
+  &.syntax--regexp {
     color: @gruvbox-bright-red;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @gruvbox-bright-yellow;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @gruvbox-bright-blue;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @gruvbox-medium;
     }
 
-    &.tag { color: @gruvbox-bright-blue; }
+    &.syntax--tag { color: @gruvbox-bright-blue; }
 
-    &.method-parameters,
-    &.function-parameters,
-    &.parameters,
-    &.separator,
-    &.seperator,
-    &.array {
+    &.syntax--method-parameters,
+    &.syntax--function-parameters,
+    &.syntax--parameters,
+    &.syntax--separator,
+    &.syntax--seperator,
+    &.syntax--array {
       color: @syntax-fg;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @gruvbox-bright-green;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @gruvbox-bright-yellow;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @gruvbox-bright-red;
       font-style: italic;
     }
   }
 
-  &.section {
-    &.embedded {
+  &.syntax--section {
+    &.syntax--embedded {
       color: @gruvbox-bright-blue;
     }
 
-    &.method,
-    &.class,
-    &.inner-class {
+    &.syntax--method,
+    &.syntax--class,
+    &.syntax--inner-class {
       color: @syntax-fg;
     }
   }
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color: @gruvbox-bright-yellow;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @gruvbox-bright-orange;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @gruvbox-bright-green;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @gruvbox-bright-green;
   }
 
-  &.name.class,
-  &.name.type.class {
+  &.syntax--name.syntax--class,
+  &.syntax--name.syntax--type.syntax--class {
     color: @gruvbox-bright-yellow;
-    .punctuation.separator {
+    .syntax--punctuation.syntax--separator {
       color: @syntax-fg;
     }
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @gruvbox-bright-green;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @gruvbox-bright-blue;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @gruvbox-bright-purple;
 
-    &.id {
+    &.syntax--id {
       color: @gruvbox-bright-green;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @gruvbox-bright-yellow;
 
-    &.body {
+    &.syntax--body {
       color: @syntax-fg;
     }
   }
 
-  &.method-call,
-  &.method {
+  &.syntax--method-call,
+  &.syntax--method {
     color: @syntax-fg;
   }
 
-  &.definition {
-    &.variable {
+  &.syntax--definition {
+    &.syntax--variable {
       color: @gruvbox-bright-blue;
     }
   }
 
-  &.link {
+  &.syntax--link {
     color: @gruvbox-bright-purple;
   }
 
-  &.require {
+  &.syntax--require {
     color: @gruvbox-bright-green;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @gruvbox-bright-red;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: #373b41;
     color: @syntax-fg;
   }
 
-  &.tag {
+  &.syntax--tag {
     color: @syntax-fg;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-fg;
 }
 
 // Languages -------------------------------------------------
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @gruvbox-bright-purple;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @gruvbox-bright-red;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @gruvbox-bright-blue;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @gruvbox-bright-red;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @gruvbox-bright-green;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @gruvbox-bright-yellow;
   }
 
-  &.list {
+  &.syntax--list {
     color: @gruvbox-bright-blue;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @gruvbox-bright-purple;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @gruvbox-bright-yellow;
   }
 }

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,5 +1,5 @@
-.source.cs {
-  .keyword.operator {
+.syntax--source.syntax--cs {
+  .syntax--keyword.syntax--operator {
     color: @gruvbox-bright-red;
   }
 }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,9 +1,9 @@
-.source.css {
+.syntax--source.syntax--css {
   // highlight properties/values if they are supported
-  .property-name,
-  .property-value {
+  .syntax--property-name,
+  .syntax--property-value {
     color: @gruvbox-light2;
-    &.support {
+    &.syntax--support {
       color: @syntax-fg;
     }
   }

--- a/styles/languages/diff.less
+++ b/styles/languages/diff.less
@@ -1,22 +1,22 @@
-.source.diff {
+.syntax--source.syntax--diff {
   color: @gruvbox-light4;
 
-  .meta {
+  .syntax--meta {
     color: @gruvbox-bright-blue;
 
-    &.header.from-file { color: @gruvbox-bright-aqua; }
-    &.header.to-file { color: @gruvbox-bright-aqua; }
-    &.diff.range { color: @gruvbox-bright-yellow; }
-    &.diff.line-number { color: @gruvbox-bright-yellow; opacity: 1; }
+    &.syntax--header.syntax--from-file { color: @gruvbox-bright-aqua; }
+    &.syntax--header.syntax--to-file { color: @gruvbox-bright-aqua; }
+    &.syntax--diff.syntax--range { color: @gruvbox-bright-yellow; }
+    &.syntax--diff.syntax--line-number { color: @gruvbox-bright-yellow; opacity: 1; }
   }
 
-  .markup {
-    &.deleted { color: @gruvbox-bright-red; }
-    &.inserted { color: @gruvbox-bright-green; }
+  .syntax--markup {
+    &.syntax--deleted { color: @gruvbox-bright-red; }
+    &.syntax--inserted { color: @gruvbox-bright-green; }
   }
-  .punctuation {
-    &.deleted { color: @gruvbox-bright-red; }
-    &.inserted { color: @gruvbox-bright-green; }
-    &.range { color: @gruvbox-bright-yellow; }
+  .syntax--punctuation {
+    &.syntax--deleted { color: @gruvbox-bright-red; }
+    &.syntax--inserted { color: @gruvbox-bright-green; }
+    &.syntax--range { color: @gruvbox-bright-yellow; }
   }
 }

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,16 +1,16 @@
-.source.gfm {
-  .markup {
+.syntax--source.syntax--gfm {
+  .syntax--markup {
     -webkit-font-smoothing: auto;
-    &.heading {
+    &.syntax--heading {
       color: @gruvbox-bright-blue;
     }
 
-    &.link {
+    &.syntax--link {
       color: @gruvbox-bright-red;
     }
   }
 
-  .link .entity {
+  .syntax--link .syntax--entity {
     color: @gruvbox-bright-green;
   }
 }

--- a/styles/languages/ini.less
+++ b/styles/languages/ini.less
@@ -1,5 +1,5 @@
-.source.ini {
-  .keyword.other.definition.ini {
+.syntax--source.syntax--ini {
+  .syntax--keyword.syntax--other.syntax--definition.syntax--ini {
     color: @gruvbox-bright-blue;
   }
 }

--- a/styles/languages/java.less
+++ b/styles/languages/java.less
@@ -1,20 +1,20 @@
-.source.java {
-  .storage {
-    &.modifier.import {
+.syntax--source.syntax--java {
+  .syntax--storage {
+    &.syntax--modifier.syntax--import {
       color: @gruvbox-bright-yellow;
     }
 
-    &.type {
+    &.syntax--type {
       color: @gruvbox-bright-yellow;
     }
   }
 }
 
-.source.java-properties {
-  .meta.key-pair {
+.syntax--source.syntax--java-properties {
+  .syntax--meta.syntax--key-pair {
     color: @gruvbox-bright-blue;
 
-    & > .punctuation {
+    & > .syntax--punctuation {
       color: @syntax-fg;
     }
   }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,20 +1,20 @@
-.source.json {
-  .meta.structure.dictionary.json {
-    & > .string.quoted.json {
-      & > .punctuation.string {
+.syntax--source.syntax--json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+    & > .syntax--string.syntax--quoted.syntax--json {
+      & > .syntax--punctuation.syntax--string {
         color: @gruvbox-bright-blue;
       }
       color: @gruvbox-bright-blue;
     }
   }
 
-  .meta.structure.dictionary.json, .meta.structure.array.json {
-    & > .value.json > .string.quoted.json,
-    & > .value.json > .string.quoted.json > .punctuation {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
       color: @gruvbox-bright-yellow;
     }
 
-    & > .constant.language.json {
+    & > .syntax--constant.syntax--language.syntax--json {
       color: @gruvbox-bright-red;
     }
   }

--- a/styles/languages/python.less
+++ b/styles/languages/python.less
@@ -1,9 +1,9 @@
-.source.python {
-  .keyword.operator.logical.python {
+.syntax--source.syntax--python {
+  .syntax--keyword.syntax--operator.syntax--logical.syntax--python {
     color: @gruvbox-bright-red;
   }
 
-  .variable.parameter {
+  .syntax--variable.syntax--parameter {
     color: @gruvbox-bright-purple;
   }
 }

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,9 +1,9 @@
-.source.ruby {
-  .constant.other.symbol > .punctuation {
+.syntax--source.syntax--ruby {
+  .syntax--constant.syntax--other.syntax--symbol > .syntax--punctuation {
     color: inherit;
   }
 
-  .punctuation.separator.namespace {
+  .syntax--punctuation.syntax--separator.syntax--namespace {
     color: @gruvbox-bright-yellow;
   }
 }


### PR DESCRIPTION
As of Atom v1.13.0 they are [deprecating some CSS selectors](https://github.com/atom/atom/pull/12903) this PR removes the `:host` selector and updates all the necessary selectors to prepend the new `syntax--` label.