### PR TITLE
Add syntax highlighting for CSS constants Atom 1.13.0

### DIFF
--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,15 +1,15 @@
-.source.css {
+.syntax--source.syntax--css {
   // highlight properties/values if they are supported
-  .property-name {
+  .syntax--property-name {
     color: @gruvbox-light2;
   }
 
-  .property-value {
+  .syntax--property-value {
     color: @gruvbox-light2;
-    &.support {
+    &.syntax--support {
       color: @syntax-fg;
     }
-    &.constant {
+    &.syntax--constant {
       color: @gruvbox-bright-blue;
     }
   }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,10 +1,16 @@
 .source.css {
   // highlight properties/values if they are supported
-  .property-name,
+  .property-name {
+    color: @gruvbox-light2;
+  }
+
   .property-value {
     color: @gruvbox-light2;
     &.support {
       color: @syntax-fg;
+    }
+    &.constant {
+      color: @gruvbox-bright-blue;
     }
   }
 }


### PR DESCRIPTION
This adds syntax highlighting for constants in CSS. Such as `relative`, `absolute` and `block`.

NOTE: this uses the *new* syntax for Atom 1.13.0 and so would be easier to be merged after #7 

Old:
![screenshot 2017-01-27 14 16 33](https://cloud.githubusercontent.com/assets/11544418/22373827/7119149e-e49b-11e6-9949-1513e813dbe0.png)

New:
![screenshot 2017-01-27 14 17 07](https://cloud.githubusercontent.com/assets/11544418/22373830/77dddd8c-e49b-11e6-8e0d-67c134b534c2.png)
